### PR TITLE
docs: Expand GitHub token security guidance (Iara suggestions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ GITHUB_PERSONAL_ACCESS_TOKEN=ghp_...
 
 > **Migração:** Se você usava `mcp.json` para configurar o GitHub, basta mover o token para o `.env` e remover o `mcp.json`. A skill agora é carregada automaticamente via `skills/github.py`.
 
-> **Segurança:** Use um token com permissões mínimas (ex: `repo` read-only). O `.env` já está no `.gitignore`.
+> **Segurança:** Crie um [Personal Access Token (classic)](https://github.com/settings/tokens) com os **escopos mínimos necessários**:
+> - `repo` (read-only) — para listar repositórios e issues
+> - `read:org` — se precisar acessar repos de organizações
+>
+> O `.env` já está no `.gitignore`. Variáveis de ambiente do sistema têm precedência sobre o `.env`.
 
 ### 6. Executar
 ```bash


### PR DESCRIPTION
## Resumo

Aplica as sugestões menores da Iara no review do PR#41.

### Alterações

- **README.md**: Expandida a seção de configuração do GitHub com:
  - Escopos específicos recomendados (`repo` read-only, `read:org`)
  - Link direto para a página de criação de tokens do GitHub
  - Nota sobre precedência de variáveis de ambiente do sistema sobre `.env`

### Sugestões da Iara verificadas

| Sugestão | Status |
|----------|--------|
| Remover `mcp.json` do `.gitignore` | ✅ Já não existe |
| Documentar token scope mínimo | ✅ Implementado neste PR |
| Timeout mismatch (30s vs 10m) | ℹ️ Intencional: 30s por teste, 10m por job |