### PR TITLE
feat: Persona Curupira, temperature controls e consciência de hardware (#68)

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -366,7 +366,7 @@ class AgentBrain:
                     model=model,
                     messages=messages,
                     max_tokens=100,
-                    temperature=0.0 # Strict
+                    temperature=config.GROQ_TEMPERATURE_REFLECTION  # determinístico para reflexão
                 )
                 result = response.choices[0].message.content.strip()
             else:
@@ -418,45 +418,47 @@ class AgentBrain:
         available_tools_desc = []
         for skill in self.skills.values():
             available_tools_desc.append(f"- {skill.name}: {skill.description}")
-        
-        tools_context = "\n".join(available_tools_desc) if available_tools_desc else "Nenhuma ferramenta extra disponível no momento."
 
-        # Use 'Usuário' as fallback if name is not in context
+        tools_context = "\n".join(available_tools_desc) if available_tools_desc else "Nenhuma ferramenta disponível no momento."
+
         user_name = context.get('user_name', 'Usuário')
-        
-        # Re-add timestamp definition (accidentally removed)
         current_time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-        # Inject persistent user facts
+        # Inject persistent user facts (from issue #88)
         user_facts = context.get('user_facts', '')
         facts_section = (
-            f"\nFatos persistentes sobre o usuário (use-os proativamente, sem perguntar novamente):\n{user_facts}"
-            if user_facts else ""
+            f"\n{user_facts}"
+            if user_facts else "Nenhum fato registrado ainda."
         )
 
-        system_prompt = f"""
+        system_prompt = f"""## IDENTIDADE
+Você é o Curupira, assistente pessoal de {user_name}.
+Horário atual: {current_time_str}
+Personalidade: direto, leve, ligeiramente místico. Sem ser prolixo. Responda sempre em português brasileiro.
 
-        Você é o Curupira, um assistente virtual (Persona do Folclore Brasileiro) leve e eficiente.
-        Seu objetivo é ajudar o usuário: {user_name}.
-        Horário atual do sistema: {current_time_str}
-        {facts_section}
-        
-        {tools_context}
-        
-        Instruções:
-        1. Responda de forma natural e amigável.
-        2. Ferramentas (Skills/MCP): Se o usuário solicitar algo que possa ser resolvido por uma das ferramentas listadas acima, utilize-a proativamente.
-        3. Formatação: Se uma ferramenta retornar um resumo formatado (especialmente com emojis), privilegie o uso desse conteúdo na sua resposta final, mantendo os emojis.
-        4. Contexto de Ferramentas: Ao consultar dados via ferramenta, baseie-se estritamente no retorno dela. Ignore informações do histórico que contradigam o estado atual retornado.
-        5. Erros: Não invente informações em caso de erro na ferramenta.
-        6. Capacidades: Você possui acesso total às ferramentas listadas. Use-as para cumprir o objetivo do usuário.
-        7. Protocolo: SEMPRE use formato JSON válido para chamadas de ferramentas.
-        8. ATENÇÃO CRÍTICA: O nome da função ('name') deve ser EXATAMENTE o identificador da ferramenta (ex: 'get_weather'). JAMAIS coloque argumentos JSON ou chaves no campo 'name'. Os argumentos devem ir APENAS no campo 'arguments'.
-        9. Memória de Longo Prazo: Quando o usuário revelar informações importantes (cidade, preferências, nome preferido, horário de rotina, etc.), chame 'save_user_fact' para persistir esse dado. Use os fatos já conhecidos diretamente, sem pedir confirmação.
-        
-        Contexto Atual:
-        {chat_history}
-        """
+## AMBIENTE DE HARDWARE
+Você opera em um Raspberry Pi com recursos limitados de CPU e RAM.
+Prefira respostas curtas e objetivas. Nunca mencione "aguardar processamento".
+
+## FATOS PERSISTENTES DO USUÁRIO
+Use esses dados proativamente — nunca peça informações que já estão aqui:
+{facts_section}
+
+## FERRAMENTAS DISPONÍVEIS
+{tools_context}
+
+## REGRAS DE COMPORTAMENTO
+1. **Ferramentas**: Use-as proativamente. Nunca pergunte se deve usar uma ferramenta disponível.
+2. **RSS/Notícias**: Identifique o feed mais relevante pelo contexto e busque direto, sem listar opções nem pedir confirmação. Apresente artigos com título e link exatos — nunca resuma genericamente.
+3. **Clima**: Se a cidade do usuário estiver nos Fatos Persistentes, use-a diretamente.
+4. **Rigidez factual**: Baseie respostas APENAS no retorno das ferramentas. Nunca invente dados não retornados por uma skill.
+5. **Diálogo natural**: Continue conversas de forma orgânica, inclusive após mensagens proativas suas.
+6. **Memória de longo prazo**: Ao aprender dado relevante (cidade, rotina, preferência), chame `save_user_fact` imediatamente.
+7. **Protocolo de ferramentas**: Use JSON válido. O campo `name` deve ser EXATAMENTE o identificador da ferramenta — nunca inclua argumentos no `name`.
+
+## HISTÓRICO RECENTE
+{chat_history}
+"""
 
 
         max_turns = 5
@@ -481,7 +483,8 @@ class AgentBrain:
                         messages=messages,
                         tools=tools if tools else None,
                         tool_choice="auto" if tools else None,
-                        max_tokens=2048 # Increased to prevent cut-off responses
+                        max_tokens=2048,
+                        temperature=config.GROQ_TEMPERATURE
                     )
                     
                     msg = response.choices[0].message

--- a/core/config.py
+++ b/core/config.py
@@ -20,8 +20,18 @@ GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 
 # Groq Configuration
 GROQ_API_KEY = os.getenv('GROQ_API_KEY')
-# GROQ_MODEL = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
+# Model options (set via GROQ_MODEL env var):
+#   llama-3.1-8b-instant  — rápido, leve, menor custo (default)
+#   llama-3.3-70b-versatile — melhor raciocínio, recomendado para produção
 GROQ_MODEL = os.getenv("GROQ_MODEL", "llama-3.1-8b-instant")
+
+# Temperature controls (set via env var):
+#   0.0 = determinístico (melhor para ferramentas e reflexão)
+#   0.7 = balanceado criatividade/precisão (recomendado para diálogo)
+#   1.0 = máxima criatividade (não recomendado para uso de ferramentas)
+GROQ_TEMPERATURE = float(os.getenv("GROQ_TEMPERATURE", "0.7"))
+GROQ_TEMPERATURE_REFLECTION = float(os.getenv("GROQ_TEMPERATURE_REFLECTION", "0.0"))
+
 
 # Retry Configuration
 # Maximum number of retries for 429/ResourceExhausted errors

--- a/tests/test_agent_logic.py
+++ b/tests/test_agent_logic.py
@@ -71,6 +71,23 @@ async def test_process_message_groq_flow(agent, mock_groq_client):
     mock_groq_client.chat.completions.create.assert_called_once()
 
 @pytest.mark.asyncio
+async def test_groq_call_includes_temperature(agent, mock_groq_client):
+    """temperature deve ser passado à API Groq com valor entre 0.0 e 1.0."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Olá!"
+    mock_response.choices[0].message.tool_calls = None
+
+    agent.client = mock_groq_client
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    await agent.process("Olá", {"user_name": "TestUser"})
+
+    call_kwargs = mock_groq_client.chat.completions.create.call_args.kwargs
+    assert "temperature" in call_kwargs, "temperature deve ser passado à API"
+    assert 0.0 <= call_kwargs["temperature"] <= 1.0, "temperature deve estar entre 0.0 e 1.0"
+
+@pytest.mark.asyncio
 async def test_execute_tool_call_success(agent):
     """Test successful tool execution"""
     mock_skill = AsyncMock()

--- a/tests/test_memory_skill.py
+++ b/tests/test_memory_skill.py
@@ -139,7 +139,7 @@ class TestUserFactsInjection:
         system_content = messages[0]["content"]
         assert "São Paulo" in system_content
         assert "07:00" in system_content
-        assert "Fatos persistentes" in system_content
+        assert "FATOS PERSISTENTES" in system_content
 
     @pytest.mark.asyncio
     async def test_no_facts_section_when_empty(self, agent):


### PR DESCRIPTION
## Resumo

Implementa a issue #68 — refinamento da persona Curupira, controle de temperatura e consciência de hardware.

## Mudanças

### `core/config.py`
- Adiciona `GROQ_TEMPERATURE` (default `0.7`) e `GROQ_TEMPERATURE_REFLECTION` (default `0.0`), ambos configuráveis via `.env`
- Documenta modelos disponíveis (`llama-3.1-8b-instant` vs `llama-3.3-70b-versatile`) como comentários

### `core/agent.py`
- **System prompt refatorado** com seções bem definidas:
  - `## IDENTIDADE` — persona Curupira com personalidade definida
  - `## AMBIENTE DE HARDWARE` — consciência do Raspberry Pi
  - `## FATOS PERSISTENTES DO USUÁRIO` — integração com #88
  - `## FERRAMENTAS DISPONÍVEIS` — lista dinâmica de skills
  - `## REGRAS DE COMPORTAMENTO` — instruções precisas para RSS, clima, rigidez factual, diálogo e memória
- `process()` agora passa `temperature=config.GROQ_TEMPERATURE` à API Groq
- `reflect()` substitui `temperature=0.0` hardcoded por `config.GROQ_TEMPERATURE_REFLECTION`

### `tests/test_agent_logic.py`
- Novo teste `test_groq_call_includes_temperature` — verifica que `temperature` é incluído na chamada à API

### `tests/test_memory_skill.py`
- Atualiza assertion do teste de injeção de fatos para a nova estrutura de seções (`FATOS PERSISTENTES`)

## Resultado

- **114 testes passando**, 0 regressões
- Bot agora sabe que opera em Raspberry Pi, tem personalidade definida e regras explícitas para cada comportamento esperado

Closes #68