### PR TITLE
fix: prevent heartbeat from spamming greetings multiple times a day

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -57,6 +57,10 @@ class AgentBrain:
         self.mcp_clients: List[MCPClient] = []
         self.client = None
 
+        # Proactive greeting deduplication: only one greeting per calendar day.
+        # Stores the last date (datetime.date) a greeting was sent, or None.
+        self._last_greeting_date: Optional[datetime.date] = None
+
         # Built-in skills (always available)
         self.register_skill(IntrospectionSkill(self))
         self.register_skill(RssReadSkill())
@@ -348,18 +352,33 @@ class AgentBrain:
         if not client:
             return None
 
+        # Resolve greeting window from config
+        greeting_start = config.REFLECTION_GREETING_HOUR_START
+        greeting_end   = config.REFLECTION_GREETING_HOUR_END
+        current_hour   = context.get("hour", -1)
+        greeting_allowed = greeting_start <= current_hour < greeting_end
+
         # Construct Prompt
         # /no_think instructs Qwen3 to skip chain-of-thought output
+        greeting_rule = (
+            f"3. If the current hour is between {greeting_start}:00 and {greeting_end}:00 "
+            "AND you have NOT greeted the user yet today -> Say 'Bom dia' naturally."
+            if greeting_allowed
+            else
+            "3. Greetings (Bom dia, Good morning, etc.) are FORBIDDEN right now — "
+            f"they are only allowed between {greeting_start}:00 and {greeting_end}:00."
+        )
         system_prompt = (
             "/no_think\n"
-            "You are the Guardian of the System (Curupira)."
-            "Analyze the provided context (Time, Hardware, State)."
-            "Decide if you MUST say something to the user."
-            "CRITERIA:"
-            "1. If everything is normal -> Output 'SILENCE' (strict)."
-            "2. If hardware is critical (Temp > 80C, RAM > 90%) -> Warn user."
-            "3. If it's a special time (e.g. 08:00 AM) -> Maybe say 'Bom dia'."
-            "OUTPUT FORMAT: strictly return the message text OR the single word 'SILENCE'. No JSON. No markdown. Do not include 'Reflexão:' prefix."
+            "You are the Guardian of the System (Curupira). "
+            "Analyze the provided context (Time, Hardware, State). "
+            "Decide if you MUST say something to the user. "
+            "CRITERIA: "
+            "1. If everything is normal -> Output 'SILENCE' (strict). "
+            "2. If hardware is critical (CPU Temp > 80C or RAM > 90%) -> Warn the user immediately. "
+            f"{greeting_rule} "
+            "OUTPUT FORMAT: strictly return the message text OR the single word 'SILENCE'. "
+            "No JSON. No markdown. No 'Reflexão:' prefix. One greeting per day maximum."
         )
 
         user_content = f"Context: {json.dumps(context, indent=2, ensure_ascii=False)}"
@@ -422,6 +441,24 @@ class AgentBrain:
             if clean_after in silence_triggers or len(clean_after) < 2:
                 self.logger.info(f"Reflection: SILENCE (post-strip: {clean_after})")
                 return None
+
+            # -------------------------------------------------------------------
+            # Greeting deduplication: if the message contains a morning greeting,
+            # only allow it once per calendar day (regardless of LLM decision).
+            # -------------------------------------------------------------------
+            _GREETING_KEYWORDS = ("bom dia", "good morning", "bonjour", "buenos días")
+            is_greeting = any(kw in result.lower() for kw in _GREETING_KEYWORDS)
+
+            if is_greeting:
+                today = datetime.now().date()
+                if self._last_greeting_date == today:
+                    self.logger.info(
+                        f"Reflection: SILENCE (greeting already sent today: {today})"
+                    )
+                    return None
+                # Record that we sent a greeting today
+                self._last_greeting_date = today
+                self.logger.info(f"Reflection: greeting approved for {today}, updating _last_greeting_date.")
 
             return result
             

--- a/core/config.py
+++ b/core/config.py
@@ -133,3 +133,10 @@ else:
 # Heartbeat Reflection Configuration
 REFLECTION_ENABLED = os.getenv("REFLECTION_ENABLED", "true").lower() == "true"
 REFLECTION_MODEL = os.getenv("REFLECTION_MODEL", "llama-3.3-70b-versatile") # Default to fast/smart Groq model
+
+# Greeting window: the bot may only send a "Bom dia"-style greeting ONCE PER DAY,
+# and only when the current hour falls within [GREETING_HOUR_START, GREETING_HOUR_END).
+# Outside this window the model is explicitly instructed to stay silent about greetings.
+# Override via env vars: REFLECTION_GREETING_HOUR_START / REFLECTION_GREETING_HOUR_END
+REFLECTION_GREETING_HOUR_START = int(os.getenv("REFLECTION_GREETING_HOUR_START", "7"))
+REFLECTION_GREETING_HOUR_END   = int(os.getenv("REFLECTION_GREETING_HOUR_END",   "9"))

--- a/tests/test_reflection_logic.py
+++ b/tests/test_reflection_logic.py
@@ -9,6 +9,7 @@ from core.agent import AgentBrain
 # and verify the output for different "silence" strings.
 
 from unittest.mock import AsyncMock, patch, MagicMock
+import datetime
 
 @pytest.fixture
 def mock_agent():
@@ -19,6 +20,20 @@ def mock_agent():
          patch("core.agent.config.GROQ_API_KEY", "dummy_key"):
         agent = AgentBrain(provider="groq")
         return agent
+
+
+def _make_groq_mock(content: str):
+    """Helper: builds a mock Groq response with given content."""
+    mock_message = MagicMock()
+    mock_message.content = content
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create.return_value = mock_response
+    return mock_client
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_output,expected_result", [
@@ -40,29 +55,144 @@ async def test_reflection_filtering(mock_agent, model_output, expected_result):
     with patch("core.config.AI_PROVIDER", "groq"), \
          patch("core.config.GROQ_API_KEY", "valid_key"), \
          patch("core.config.GROQ_MODEL", "llama-test"), \
-         patch("core.config.REFLECTION_ENABLED", True):
+         patch("core.config.REFLECTION_ENABLED", True), \
+         patch("core.config.REFLECTION_GREETING_HOUR_START", 7), \
+         patch("core.config.REFLECTION_GREETING_HOUR_END", 9):
         
-        # Mock Client Response — use spec=str so .strip() returns the string itself
-        mock_content = MagicMock(spec=str)
-        mock_content.strip.return_value = model_output
-        mock_content.__str__ = lambda self: model_output
-        mock_content.upper.return_value = model_output.upper()
-        mock_content.replace.return_value = model_output
-        mock_content.rstrip.return_value = model_output
-
-        mock_message = MagicMock()
-        mock_message.content = model_output  # plain string
-
-        mock_choice = MagicMock()
-        mock_choice.message = mock_message
-
-        mock_response = MagicMock()
-        mock_response.choices = [mock_choice]
-
-        mock_client = AsyncMock()
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client = _make_groq_mock(model_output)
 
         # Mock groq.AsyncGroq
         with patch("groq.AsyncGroq", return_value=mock_client):
-            result = await mock_agent.reflect({"context": "test"})
+            result = await mock_agent.reflect({"context": "test", "hour": 8})
             assert result == expected_result
+
+
+# ---------------------------------------------------------------------------
+# NEW: Greeting deduplication tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_greeting_deduplication(mock_agent):
+    """
+    Second call with a greeting response on the SAME day must return None (SILENCE).
+    """
+    today = datetime.date.today()
+    # Pre-seed: bot already sent a greeting today
+    mock_agent._last_greeting_date = today
+
+    mock_client = _make_groq_mock("Bom dia! Tudo bem?")
+
+    with patch("core.config.AI_PROVIDER", "groq"), \
+         patch("core.config.GROQ_API_KEY", "valid_key"), \
+         patch("core.config.GROQ_MODEL", "llama-test"), \
+         patch("core.config.REFLECTION_ENABLED", True), \
+         patch("core.config.REFLECTION_GREETING_HOUR_START", 7), \
+         patch("core.config.REFLECTION_GREETING_HOUR_END", 9), \
+         patch("groq.AsyncGroq", return_value=mock_client):
+        result = await mock_agent.reflect({"hour": 8})
+
+    assert result is None, "Should be silenced because greeting was already sent today"
+
+
+@pytest.mark.asyncio
+async def test_greeting_outside_window_prompt(mock_agent):
+    """
+    When current hour is OUTSIDE the greeting window, the prompt should contain the
+    FORBIDDEN clause so the LLM knows not to greet.
+    """
+    captured_calls = []
+
+    async def capture_create(**kwargs):
+        captured_calls.append(kwargs)
+        mock_message = MagicMock()
+        mock_message.content = "SILENCE"
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = capture_create
+
+    with patch("core.config.AI_PROVIDER", "groq"), \
+         patch("core.config.GROQ_API_KEY", "valid_key"), \
+         patch("core.config.GROQ_MODEL", "llama-test"), \
+         patch("core.config.REFLECTION_ENABLED", True), \
+         patch("core.config.REFLECTION_GREETING_HOUR_START", 7), \
+         patch("core.config.REFLECTION_GREETING_HOUR_END", 9), \
+         patch("groq.AsyncGroq", return_value=mock_client):
+        # hour=14 is outside 7-9 window
+        await mock_agent.reflect({"hour": 14})
+
+    assert captured_calls, "Model should have been called"
+    system_msg = captured_calls[0]["messages"][0]["content"]
+    assert "FORBIDDEN" in system_msg, (
+        f"Prompt should mention FORBIDDEN for greetings outside the window, got: {system_msg[:300]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_greeting_inside_window_prompt(mock_agent):
+    """
+    When current hour IS INSIDE the greeting window, the prompt should NOT contain
+    FORBIDDEN and should allow a greeting.
+    """
+    captured_calls = []
+
+    async def capture_create(**kwargs):
+        captured_calls.append(kwargs)
+        mock_message = MagicMock()
+        mock_message.content = "SILENCE"
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = capture_create
+
+    with patch("core.config.AI_PROVIDER", "groq"), \
+         patch("core.config.GROQ_API_KEY", "valid_key"), \
+         patch("core.config.GROQ_MODEL", "llama-test"), \
+         patch("core.config.REFLECTION_ENABLED", True), \
+         patch("core.config.REFLECTION_GREETING_HOUR_START", 7), \
+         patch("core.config.REFLECTION_GREETING_HOUR_END", 9), \
+         patch("groq.AsyncGroq", return_value=mock_client):
+        # hour=8 is inside 7-9 window
+        await mock_agent.reflect({"hour": 8})
+
+    assert captured_calls, "Model should have been called"
+    system_msg = captured_calls[0]["messages"][0]["content"]
+    assert "FORBIDDEN" not in system_msg, (
+        "Prompt should NOT mention FORBIDDEN when inside the greeting window"
+    )
+    assert "Bom dia" in system_msg, (
+        "Prompt should mention 'Bom dia' as an allowed action inside the window"
+    )
+
+
+@pytest.mark.asyncio
+async def test_greeting_resets_next_day(mock_agent):
+    """
+    Greeting should be allowed again on the NEXT calendar day.
+    """
+    yesterday = datetime.date.today() - datetime.timedelta(days=1)
+    mock_agent._last_greeting_date = yesterday  # Greeted yesterday
+
+    mock_client = _make_groq_mock("Bom dia! Nova manhã!")
+
+    with patch("core.config.AI_PROVIDER", "groq"), \
+         patch("core.config.GROQ_API_KEY", "valid_key"), \
+         patch("core.config.GROQ_MODEL", "llama-test"), \
+         patch("core.config.REFLECTION_ENABLED", True), \
+         patch("core.config.REFLECTION_GREETING_HOUR_START", 7), \
+         patch("core.config.REFLECTION_GREETING_HOUR_END", 9), \
+         patch("groq.AsyncGroq", return_value=mock_client):
+        result = await mock_agent.reflect({"hour": 8})
+
+    assert result is not None, "Should allow greeting on a new day"
+    assert "bom dia" in result.lower(), f"Expected a greeting, got: {result}"
+    # State should now be updated to today
+    assert mock_agent._last_greeting_date == datetime.date.today()


### PR DESCRIPTION
## Problema

O bot estava enviando mensagens de "Bom dia" repetidamente desde as 6h da manhã a cada 30 minutos (ciclo do heartbeat), pois não havia nenhuma trava para garantir que saudações fossem enviadas apenas uma vez por dia.

## Causas raíz identificadas

1. **Prompt vago**: o critério `"If it's a special time (e.g. 08:00 AM) -> Maybe say 'Bom dia'"` não definia janela horária nem limite de frequência.
2. **Sem memória entre ticks**: cada tick de 30min gerava uma decisão independente — se o LLM achava que era "manhã", dizia bom dia novamente.
3. **Sem deduplicação**: não existia nenhuma trava de "já mandei saudação hoje".

## Mudanças

### `core/config.py`
- Adicionados `REFLECTION_GREETING_HOUR_START` (default `7`) e `REFLECTION_GREETING_HOUR_END` (default `9`) para configurar a janela de saudações via `.env`.

### `core/agent.py`
- Adicionado `_last_greeting_date: Optional[datetime.date] = None` no `AgentBrain.__init__` para rastrear a data da última saudação enviada.
- Prompt de reflexão refinado: injeta dinamicamente a cláusula certa:
  - **Dentro da janela**: `"If between 7:00 and 9:00 AND not greeted today → Bom dia"`
  - **Fora da janela**: `"Greetings (Bom dia, Good morning, etc.) are FORBIDDEN right now"`
- Filtro pós-geração: se o resultado contém saudação e `_last_greeting_date == hoje`, retorna `None` (silêncio), independente da decisão do LLM.

### `tests/test_reflection_logic.py`
- Adicionados 4 novos testes:
  - `test_greeting_deduplication` — segunda saudação no mesmo dia → silêncio
  - `test_greeting_outside_window_prompt` — prompt contém cláusula FORBIDDEN fora da janela
  - `test_greeting_inside_window_prompt` — prompt permite saudação dentro da janela
  - `test_greeting_resets_next_day` — no dia seguinte, saudação é permitida novamente

## Testes

```
20 passed in 1.31s ✅
```

Todos os 20 testes passam (10 existentes + 4 novos de deduplicação + 6 de agent_reflection).