### PR TITLE
feat: Implement time-based session memory window & roadmap update (#70)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,21 +59,43 @@
 
 ---
 
-## 🔮 Backlog Priorizado (Q1 2026)
+### 🎯 Job Hunter
+- [x] **Busca de Vagas:** Integração com APIs externas de busca. (Issue #95)
+- [x] **Avaliação de IA:** Avaliação e scoring de vagas relevantes baseadas nas preferências do usuário.
+- [x] **Configuração flexível:** Opções para domínios, keywords e prompt override.
 
-### 🚀 Prioridade Alta (Core Assistant)
-Estas skills transformam o Curupira em um assistente pessoal proativo.
-- [ ] **Google Agenda:** Gestão completa de calendário (OAuth). (Issue #48)
-- [ ] **Compreensão de Áudio:** Transcrição e resposta a áudios. (Issue #60)
+---
 
+## 📦 Releases Planejados (Milestones)
 
-### 🛠️ Prioridade Média (Produtividade)
-Ferramentas de produtividade pessoal.
-- [ ] **Tempo de Transporte:** Rotas e trânsito (Maps). (Issue #61)
-- [ ] **Emails:** Leitura e envio. (Issue #50)
-- [ ] **Notion:** Segundo cérebro. (Issue #49)
+### 🚀 v0.10.0: O "Jarvis" Proativo e Contextual
+Foco em dar iniciativa ao bot, melhorias na injeção de contexto e aprimoramento contínuo da UX de conversação (Memory & Persona).
+- [ ] **Scoring de Memória (Facts):** Sistema de prioridade para fatos persistentes do usuário no prompt. (Issue #90)
+- [ ] **Grounding Dinâmico:** Injeção de contexto vital (Hora atual, Load, etc) pré-prompt. (Issue #70)
+- [ ] **Fluxo de RSS Claro:** Listagem individualizada com links vs resumos genéricos. (Issue #87)
+- [ ] **Persistência Proativa:** Mensagens proativas no histórico para continuidade. (Issue #85)
+- [ ] **Multi-turn/Streaming UX:** Suporte para conversação natural pré-tools e streaming responses. (Issue #81)
 
-### 🤓 Prioridade Baixa (DevOps & Tools)
-Monitoramento técnico e entretenimento.
-- [ ] **Monitoramento:** Vercel (#45), Analytics (#47), Logs (#53).
-- [ ] **Outros:** PDF (#46), Entretenimento (#59).
+### 🛠️ v0.11.0: Confiabilidade e Arquitetura Agêntica Avançada
+Foco na saúde do sistema e evolução das capacidades técnicas (MCP-Lite) usando ferramentas orientadas a sistema.
+- [ ] **Doctor (Health Checks):** Diagnóstico de integridade do ambiente (ZRAM, Chaves, Git). (Issue #72)
+- [ ] **Padronização MCP-Lite:** Isolar lógicas das skills para retorno JSON padronizado. (Issue #71)
+- [ ] **Skill de Terminal (Power User):** Execução segura de comandos shell locais. (Issue #42)
+- [ ] **Monitoramento de Logs:** Detecção de anomalias no sistema. (Issue #53)
+
+### 💼 v1.0.0: O Assistente Pessoal Completo ("Day-to-day Helper")
+Integrações essenciais para rotina e facilidades da vida pessoal.
+- [ ] **Compreensão de Áudio:** Ouvir e processar solicitações via voz. (Issue #60)
+- [ ] **Google Agenda:** Gestão completa e cruzamento de horários. (Issue #48)
+- [ ] **Tempo de Transporte:** Consultas de rotas e estimativa (Maps). (Issue #61)
+- [ ] **Compras Inteligentes:** Gerenciamento e auxílio em compras de casa/mantimentos. (Issue #62)
+
+### 📈 v1.1.0: Produtividade Profissional e Tools
+Ferramentas direcionadas para ganho de produtividade no trabalho e integrações corporativas.
+- [ ] **E-mails v1.0:** Leitura e envio de anexos (SMTP/Resend). (Issue #50)
+- [ ] **Sistema de Arquivos:** Operações de I/O por linguagem natural. (Issue #43)
+- [ ] **Leitor de Documentos (PDF):** Síntese estruturada de relatórios PDF. (Issue #46)
+- [ ] **Navegação Web Headless:** Acesso e extração de URLs sem API (BS4/Trafilatura). (Issue #44)
+- [ ] **Integração Notion:** Construção e input pro "segundo cérebro". (Issue #49)
+- [ ] **Entretenimento (Cinema/Teatro):** Busca de diversão local via APIs. (Issue #59)
+- [ ] **Vercel & Analytics:** Reports, logs e stats básicos (Dev/Prod). (Issues #45, #47)

--- a/bot.py
+++ b/bot.py
@@ -128,8 +128,8 @@ async def responder(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
     # --- ONBOARDING FLOW END ---
     
-    # 2. Retrieve Context
-    context_history = await memory_manager.get_context(user_id)
+    # 2. Retrieve Context (Session Memory: Max 20 msgs in the last 30 minutes)
+    context_history = await memory_manager.get_context(user_id, limit=20, minutes_ago=30)
     user_facts = await memory_manager.get_facts(user_id)
     assistant_surname = await memory_manager.get_fact_value(user_id, "assistant_surname") or ""
 

--- a/skills/memory.py
+++ b/skills/memory.py
@@ -161,14 +161,17 @@ class MemoryManager:
             """, (user_id, role, content, datetime.now()))
             await db.commit()
 
-    async def get_context(self, user_id, limit=10):
-        """Retrieves the last N messages for context injection."""
+    async def get_context(self, user_id, limit=20, minutes_ago=30):
+        """Retrieves the recent messages for context injection within a timeframe."""
+        from datetime import timedelta
+        cutoff_time = datetime.now() - timedelta(minutes=minutes_ago)
+        
         async with aiosqlite.connect(self.db_path) as db:
             async with db.execute("""
                 SELECT role, content FROM conversations 
-                WHERE user_id = ? 
+                WHERE user_id = ? AND timestamp >= ?
                 ORDER BY id DESC LIMIT ?
-            """, (user_id, limit)) as cursor:
+            """, (user_id, cutoff_time, limit)) as cursor:
                 rows = await cursor.fetchall()
                 # Reverse to correct chronological order
                 history = reversed(rows)

--- a/tests/test_memory_skill.py
+++ b/tests/test_memory_skill.py
@@ -201,3 +201,82 @@ class TestMemoryManagerMigration:
             await mm.init_db()
         finally:
             os.unlink(db_path)
+
+# ---------------------------------------------------------------------------
+# MemoryManager get_context session memory (Issue #70)
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, timedelta
+
+class TestGetContextSessionMemory:
+    @pytest.mark.asyncio
+    async def test_get_context_filters_by_minutes_ago(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            mm = MemoryManager(db_path=db_path)
+            await mm.init_db()
+            
+            await mm.add_user(user_id=1, username="test", full_name="Test User")
+            
+            now = datetime.now()
+            
+            async with aiosqlite.connect(db_path) as db:
+                # 1 hour ago (should be excluded)
+                await db.execute(
+                    "INSERT INTO conversations (user_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+                    (1, "user", "Old message", now - timedelta(hours=1))
+                )
+                # 10 minutes ago (should be included)
+                await db.execute(
+                    "INSERT INTO conversations (user_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+                    (1, "model", "Recent reply", now - timedelta(minutes=10))
+                )
+                # Just now (should be included)
+                await db.execute(
+                    "INSERT INTO conversations (user_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+                    (1, "user", "Hello now", now)
+                )
+                await db.commit()
+
+            # Retrieve with 30 minutes window
+            context = await mm.get_context(user_id=1, limit=10, minutes_ago=30)
+            
+            assert "Old message" not in context
+            assert "Recent reply" in context
+            assert "Hello now" in context
+            
+            # Verify chronological order
+            assert context.find("Recent reply") < context.find("Hello now")
+            
+        finally:
+            os.unlink(db_path)
+            
+    @pytest.mark.asyncio
+    async def test_get_context_respects_limit(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            mm = MemoryManager(db_path=db_path)
+            await mm.init_db()
+            await mm.add_user(user_id=1, username="test", full_name="Test User")
+            
+            now = datetime.now()
+            async with aiosqlite.connect(db_path) as db:
+                for i in range(5):
+                    await db.execute(
+                        "INSERT INTO conversations (user_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+                        (1, "user", f"Msg {i}", now)
+                    )
+                await db.commit()
+
+            # Retrieve with limit 2
+            context = await mm.get_context(user_id=1, limit=2, minutes_ago=30)
+            
+            assert "Msg 0" not in context
+            assert "Msg 1" not in context
+            assert "Msg 2" not in context
+            assert "Msg 3" in context
+            assert "Msg 4" in context
+        finally:
+            os.unlink(db_path)


### PR DESCRIPTION
Essa PR implementa as mudanças combinadas na Issue #70 (Session Memory) e atualiza o ROADMAP do projeto.

**Mudanças (Session Memory):**
- Modificado o método `get_context` em `skills/memory.py` para não focar apenas nas "últimas 10 mensagens" cruas, e sim nas mensagens **dos últimos X minutos**.
- Parâmetro padrão adotado: Janela de **30 minutos**, mantendo as últimas no máximo 20 mensagens (segurança para não estourar tokens caso haja spam de mensagens curtas em 30 mins).
- Atualizado o chamador no `bot.py` para usar esses limites com a janela de 30 minutos.
- Criada a classe de testes `TestGetContextSessionMemory` em `tests/test_memory_skill.py` para validar o limite de tempo e o chronológico.

**Mudanças (ROADMAP):**
- A antiga seção "Backlog Priorizado" foi substituída pelo novo plano de lançamentos baseados em metas claras de evolução (v0.10.0 até v1.1.0).
- Adicionada a skill `Job Hunter` à lista de implementadas.

> NOTA: O "Preflight Context" para telemetria de Hardware injetado em mensagens (parte restante da especificação original da Issue 70) foi extraído para a **[Issue #102](https://github.com/felipefernandes/curupira/issues/102)** a ser desenvolvido na sequência.