### PR TITLE
feat(sports): add get_schedule and get_standings actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+Use o arquivo README.md e PROJECT.md para obter informações gerais sobre o projeto
+
+* Contexto de Pull Request: Sempre que eu pedir para "corrigir o PR", "revisar os comentários da Iara" ou "ajustar o código com base no feedback", você deve usar o GitHub CLI ou Github MCP (se disponível) para obter o contexto atualizado.
+
+**Ações Obrigatórias**:
+1. Verifique se existe um PR aberto para a branch atual: gh pr view --web (ou apenas gh pr view).
+2. Recupere os comentários e reviews usando: gh pr view --json reviews,comments --jq '.reviews[].body, .comments[].body'
+3. Analise especificamente as sugestões da Iara (AI Code Review agent).
+4. Aplique as correções sugeridas diretamente nos arquivos locais sem que eu precise copiar e colar as mensagens.
+
+
+

--- a/skills/sports_manager.py
+++ b/skills/sports_manager.py
@@ -16,10 +16,17 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, Optional
 from collections import OrderedDict
+from urllib.parse import quote
 import httpx
 
 from skills.base import BaseSkill
 from core import config
+
+# Constantes para inferência de season
+BRAZILIAN_LEAGUE_KEYWORDS = [
+    "brasileir", "serie", "carioca", "paulist", "copa do brasil",
+    "paranaense", "gaucho", "mineiro", "baiano",
+]
 
 
 class SportsCache:
@@ -554,19 +561,22 @@ class SportsManagerSkill(BaseSkill):
 
         Ligas brasileiras usam formato ano único ("2026").
         Ligas europeias usam formato cruzado ("2025-2026").
+
+        Args:
+            league_name: Nome da liga (usado para inferir brasileiro vs europeu)
+            alternate: Se True, retorna formato oposto (usado em fallback)
+
+        Returns:
+            String de season no formato correto
         """
         now = datetime.now()
         year = now.year
         month = now.month
 
-        brazilian_keywords = [
-            "brasileir", "serie", "carioca", "paulist", "copa do brasil",
-            "paranaense", "gaucho", "mineiro", "baiano",
-        ]
         is_brazilian = False
         if league_name:
             lower_league = league_name.lower()
-            is_brazilian = any(kw in lower_league for kw in brazilian_keywords)
+            is_brazilian = any(kw in lower_league for kw in BRAZILIAN_LEAGUE_KEYWORDS)
 
         if is_brazilian and not alternate:
             return str(year)
@@ -755,7 +765,9 @@ class SportsManagerSkill(BaseSkill):
                 league_name = team_info.get("strLeague")
 
         if not league_id and league:
-            endpoint = f"search_all_teams.php?l={league}"
+            # URL-encode league name para evitar problemas com caracteres especiais
+            league_encoded = quote(league)
+            endpoint = f"search_all_teams.php?l={league_encoded}"
             data = await self._fetch_thesportsdb(endpoint)
             teams = data.get("teams") or []
             if teams:

--- a/tests/test_sports_manager.py
+++ b/tests/test_sports_manager.py
@@ -1,6 +1,7 @@
 import pytest
 import httpx
 from unittest.mock import AsyncMock, patch, MagicMock
+from datetime import datetime
 import sys
 import os
 import asyncio
@@ -855,6 +856,24 @@ def test_determine_season_none_league(sports_skill):
     assert "-" in season  # Default é formato europeu
 
 
+def test_determine_season_brazilian_month_before_july(sports_skill):
+    """Testa season brasileira com month < 7 no alternate."""
+    with patch("skills.sports_manager.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2026, 3, 15)  # Março
+        season = sports_skill._determine_season("Brasileirão", alternate=True)
+        assert "-" in season
+        assert season == "2025-2026"
+
+
+def test_determine_season_european_month_before_july(sports_skill):
+    """Testa season europeia com month < 7."""
+    with patch("skills.sports_manager.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2026, 3, 15)  # Março
+        season = sports_skill._determine_season("Premier League")
+        assert "-" in season
+        assert season == "2025-2026"
+
+
 # ==================== TESTES DE get_schedule ====================
 
 
@@ -1290,3 +1309,36 @@ async def test_execute_get_standings_without_team_but_with_league(sports_skill):
         )
 
         assert result["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_fetch_football_standings_cannot_determine_league(sports_skill):
+    """Testa erro quando não consegue determinar league_id."""
+    with patch("core.config.THESPORTSDB_KEY", "test_key"):
+        with pytest.raises(ValueError, match="determinar a liga"):
+            await sports_skill._fetch_football_standings(None, None)
+
+
+# ==================== TESTES DE shutdown ====================
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_http_client(sports_skill):
+    """Testa que shutdown() fecha o HTTP client."""
+    # Simular que o client foi criado
+    mock_client = AsyncMock()
+    sports_skill._http_client = mock_client
+
+    await sports_skill.shutdown()
+
+    # Verifica que aclose() foi chamado
+    mock_client.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_without_http_client(sports_skill):
+    """Testa que shutdown() não falha sem HTTP client."""
+    sports_skill._http_client = None
+
+    # Não deve levantar exception
+    await sports_skill.shutdown()


### PR DESCRIPTION
## Summary
Completa a Sports Manager Skill implementando `get_schedule` (próximos jogos) e `get_standings` (classificação), removendo limitações de MVP.

**Casos de uso resolvidos:**
- ✅ "Quando é o próximo jogo do Botafogo?"
- ✅ "Classificação do Brasileirão"
- ✅ "Tabela da Premier League"

## Changes

### New Actions
| Action | Endpoint | Cache TTL | Free Tier Limit |
|--------|----------|-----------|-----------------|
| `get_schedule` | `eventsnext.php` | 30 min | 1 resultado |
| `get_standings` | `lookuptable.php` | 1 hora | 5 posições |

### New Methods
- **`_resolve_team_info(team_name)`** — busca e cacheia metadata do time (24h TTL)
  - Reduz chamadas API: mesmo time usado em schedule + standings = 1 API call
- **`_determine_season(league_name, alternate)`** — infere formato de temporada
  - Ligas brasileiras: `"2026"` (ano único)
  - Ligas europeias: `"2025-2026"` (cross-year)
  - Fallback automático se primeiro formato falhar
- **`_fetch_football_schedule(team_name)`** — próximos jogos ordenados por data
- **`_fetch_football_standings(team_name, league)`** — classificação com suporte a:
  - Via `team_name`: infere liga do time
  - Via `league`: busca direto (team_name opcional)

### execute() Refactoring
- Remove gate MVP (`action != "get_results"`)
- Action dispatch com cache_key/cache_type por action
- `team_name` obrigatório para results/schedule, opcional para standings se `league` fornecido

### Free Tier Transparency
Responses incluem `free_tier_limited` boolean e `note` field:
```json
{
  "free_tier_limited": true,
  "note": "Plano gratuito da API retorna apenas 1 próximo jogo."
}
```

## Testing
- **36 → 55 tests** (+19 novos)
- **Cobertura:**
  - get_schedule: sucesso, nenhum jogo, ordenação, nota free tier
  - get_standings: via team, via league, liga não encontrada, fallback season, nota free tier
  - _resolve_team_info: cache funcionando
  - _determine_season: brasileiro vs europeu, alternates
  - execute() routing: schedule, standings, standings sem team_name

```bash
$ pytest tests/test_sports_manager.py -v
============================= 55 passed in 11.00s ==============================
```

## API Documentation Reference
TheSportsDB endpoints usados:
- `eventsnext.php?id={teamId}` - [docs](https://www.thesportsdb.com/documentation)
- `lookuptable.php?l={leagueId}&s={season}` - [docs](https://www.thesportsdb.com/documentation)
- `search_all_teams.php?l={leagueName}` - para resolver league_id

## Example Usage

**Schedule:**
```python
# User: "Quando é o próximo jogo do Botafogo?"
{
  "action": "get_schedule",
  "sport": "football",
  "team_name": "Botafogo"
}
# Response:
{
  "team_name": "Botafogo",
  "upcoming_matches": [{
    "date": "2026-03-05",
    "time": "21:00:00",
    "home_team": "Botafogo",
    "away_team": "Flamengo",
    "league": "Brasileirão Série A",
    "venue": "Estádio Nilton Santos"
  }],
  "free_tier_limited": true
}
```

**Standings:**
```python
# User: "Classificação do Brasileirão"
{
  "action": "get_standings",
  "sport": "football",
  "league": "Brasileirão Série A"
}
# Response:
{
  "league": "Brasileirão Série A",
  "season": "2026",
  "standings": [
    {"position": "1", "team_name": "Botafogo", "points": "25", ...},
    {"position": "2", "team_name": "Flamengo", "points": "23", ...}
  ],
  "free_tier_limited": true
}
```

## Verification
- [x] 55 testes passando localmente
- [ ] Testar no Raspberry Pi: "quando é o próximo jogo do Botafogo?"
- [ ] Testar no Raspberry Pi: "classificação do Brasileirão"

🤖 Generated with [Claude Code](https://claude.com/claude-code)