### PR TITLE
fix(weather): replace raw WMO code with human-readable condition description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 venv/
 env/
 .venv/
+BACKUP.env
 
 # User configuration (may contain API keys – never version this!)
 # Use default.config.toml as the template instead.

--- a/openspec/changes/fix-weather-condition-code/proposal.md
+++ b/openspec/changes/fix-weather-condition-code/proposal.md
@@ -1,0 +1,23 @@
+# Change: Fix weather skill returning raw WMO condition code to the user
+
+## Why
+
+A skill de previsão do tempo retorna ao LLM um campo `condition_code` contendo
+um número inteiro do padrão WMO (World Meteorological Organization), como `2`.
+O LLM frequentemente repassa esse código diretamente na resposta ao usuário,
+resultando em mensagens sem sentido como "O código de condição é 2." (Issue #122).
+
+## What Changes
+
+- `skills/weather_manager.py` — substituir o campo `condition_code` (inteiro bruto)
+  por `condition` (string legível em português), mapeado via tabela WMO interna
+  antes de retornar ao LLM.
+- `openspec/specs/weather/spec.md` — modificar o requisito existente para
+  especificar que a resposta DEVE incluir uma descrição textual da condição.
+
+## Impact
+
+- Affected specs: `weather`
+- Affected code: `skills/weather_manager.py`
+- Backward compatible: sim — apenas substitui um campo interno do payload JSON
+  entre a skill e o LLM; o usuário final verá linguagem natural em vez de um número.

--- a/openspec/changes/fix-weather-condition-code/specs/weather/spec.md
+++ b/openspec/changes/fix-weather-condition-code/specs/weather/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Weather Forecast
+The system MUST provide weather information when requested, utilizing external APIs.
+The weather response MUST include a human-readable condition description in Portuguese
+(e.g., "Céu limpo", "Parcialmente nublado", "Chuva moderada") instead of a raw
+WMO weather code integer. The mapping from WMO code to description MUST be resolved
+inside the skill before returning data to the LLM.
+
+#### Scenario: Explicit Location
+1. User sends: "Como está o tempo em Curitiba?".
+2. System identifies intent and city "Curitiba".
+3. System displays current temperature, humidity and a readable condition
+   description (e.g., "Céu limpo") for Curitiba.
+4. The response MUST NOT contain a numeric weather code.
+
+#### Scenario: Implicit Location (Memory)
+1. User has previously stated: "Moro em Campinas".
+2. System has stored "user_city: Campinas" in facts.
+3. User sends: "Vai chover?".
+4. System infers location "Campinas".
+5. System displays forecast for Campinas with a readable condition description.
+
+#### Scenario: Missing Location
+1. System has no location stored.
+2. User sends: "Como está o tempo?".
+3. System replies asking for the city (e.g., "De qual cidade você gostaria de saber?").
+
+#### Scenario: Unknown WMO Code
+1. The Open-Meteo API returns a weather code not present in the internal mapping table.
+2. System MUST return a safe fallback string (e.g., "Condição desconhecida (código: 99)")
+   instead of crashing or returning a bare integer.

--- a/openspec/changes/fix-weather-condition-code/tasks.md
+++ b/openspec/changes/fix-weather-condition-code/tasks.md
@@ -1,0 +1,27 @@
+## Tasks
+
+### 1. Implementação
+
+- [x] 1.1 Adicionar tabela de mapeamento WMO → descrição PT-BR em `skills/weather_manager.py`
+      (cobre os códigos 0–99 conforme documentação Open-Meteo)
+- [x] 1.2 Criar função `_wmo_description(code: int) -> str` que retorna a descrição
+      ou fallback `"Condição desconhecida (código: {code})"` para códigos ausentes
+- [x] 1.3 Substituir `"condition_code": current.get("weather_code")` por
+      `"condition": _wmo_description(current.get("weather_code", -1))`
+      no payload retornado pelo método `execute()`
+
+### 2. Testes
+
+- [x] 2.1 Adicionar testes unitários em `tests/test_weather_manager.py` cobrindo:
+      - Código conhecido → descrição correta em PT-BR (ex: `0` → `"Céu limpo"`)
+      - Código de borda (ex: `99` → "Trovoada com granizo intenso")
+      - Código desconhecido (ex: `-1` ou `999`) → fallback com o número
+- [x] 2.2 Garantir que o campo `condition_code` NÃO está mais presente no payload
+      retornado pela skill
+
+### 3. Validação
+
+- [x] 3.1 Executar suite completa de testes: `pytest --tb=short -q`
+      → 351 passed, 1 skipped
+- [ ] 3.2 Verificar manualmente no Telegram com "Como está o tempo em São Paulo?"
+      e confirmar que a resposta não contém número bruto

--- a/skills/weather_manager.py
+++ b/skills/weather_manager.py
@@ -4,6 +4,52 @@ import logging
 import asyncio
 from typing import Any, Dict
 
+# Tabela WMO Weather Interpretation Codes → Descrição PT-BR
+# Referência: https://open-meteo.com/en/docs#weather_variable_documentation
+_WMO_DESCRIPTIONS: Dict[int, str] = {
+    0:  "Céu limpo",
+    1:  "Predominantemente limpo",
+    2:  "Parcialmente nublado",
+    3:  "Nublado",
+    45: "Neblina",
+    48: "Neblina com geada",
+    51: "Chuvisco leve",
+    53: "Chuvisco moderado",
+    55: "Chuvisco intenso",
+    56: "Chuvisco gelado leve",
+    57: "Chuvisco gelado intenso",
+    61: "Chuva leve",
+    63: "Chuva moderada",
+    65: "Chuva intensa",
+    66: "Chuva gelada leve",
+    67: "Chuva gelada intensa",
+    71: "Neve leve",
+    73: "Neve moderada",
+    75: "Neve intensa",
+    77: "Grãos de neve",
+    80: "Pancadas de chuva leves",
+    81: "Pancadas de chuva moderadas",
+    82: "Pancadas de chuva violentas",
+    85: "Pancadas de neve leves",
+    86: "Pancadas de neve intensas",
+    95: "Trovoada",
+    96: "Trovoada com granizo leve",
+    99: "Trovoada com granizo intenso",
+}
+
+
+def _wmo_description(code: int) -> str:
+    """Converte um código WMO para descrição legível em PT-BR.
+
+    Args:
+        code: Código inteiro da Open-Meteo (weather_code).
+
+    Returns:
+        String descritiva em português ou fallback com o código.
+    """
+    return _WMO_DESCRIPTIONS.get(code, f"Condição desconhecida (código: {code})")
+
+
 class WeatherSkill(BaseSkill):
     def __init__(self):
         self.logger = logging.getLogger("WeatherSkill")
@@ -54,7 +100,7 @@ class WeatherSkill(BaseSkill):
             "temperature": current.get("temperature_2m"),
             "humidity": current.get("relative_humidity_2m"),
             "rain_probability": current.get("precipitation_probability", 0),
-            "condition_code": current.get("weather_code")
+            "condition": _wmo_description(current.get("weather_code", -1)),
         })
 
     async def get_coordinates(self, city_name, retries=3, backoff=2):

--- a/tests/test_weather_manager.py
+++ b/tests/test_weather_manager.py
@@ -7,7 +7,7 @@ import asyncio
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from skills.weather_manager import WeatherSkill
+from skills.weather_manager import WeatherSkill, _wmo_description, _WMO_DESCRIPTIONS
 
 @pytest.fixture
 def weather_skill():
@@ -18,6 +18,51 @@ def test_weather_skill_properties(weather_skill):
     assert weather_skill.display_name == "🌦️ Previsão do Tempo"
     assert weather_skill.description == "Obtém a previsão do tempo atual para uma cidade."
     assert "city" in weather_skill.parameters["required"]
+
+# ── Testes de _wmo_description ────────────────────────────────────────
+
+def test_wmo_description_known_clear():
+    """Código 0 → Céu limpo."""
+    assert _wmo_description(0) == "Céu limpo"
+
+def test_wmo_description_known_cloudy():
+    """Código 2 → Parcialmente nublado (era o bug reportado: 'condição 2')."""
+    assert _wmo_description(2) == "Parcialmente nublado"
+
+def test_wmo_description_known_rain():
+    """Código 61 → Chuva leve."""
+    assert _wmo_description(61) == "Chuva leve"
+
+def test_wmo_description_boundary_code_99():
+    """Código 99 (máximo WMO) → Trovoada com granizo intenso."""
+    assert _wmo_description(99) == "Trovoada com granizo intenso"
+
+def test_wmo_description_unknown_negative():
+    """Código desconhecido negativo → fallback com o número."""
+    result = _wmo_description(-1)
+    assert "desconhecida" in result
+    assert "-1" in result
+
+def test_wmo_description_unknown_large():
+    """Código fora do padrão WMO → fallback com o número."""
+    result = _wmo_description(999)
+    assert "desconhecida" in result
+    assert "999" in result
+
+def test_wmo_descriptions_table_not_empty():
+    """Tabela deve conter pelo menos os códigos básicos."""
+    assert 0 in _WMO_DESCRIPTIONS   # Céu limpo
+    assert 3 in _WMO_DESCRIPTIONS   # Nublado
+    assert 63 in _WMO_DESCRIPTIONS  # Chuva moderada
+    assert 95 in _WMO_DESCRIPTIONS  # Trovoada
+
+def test_wmo_descriptions_all_values_are_strings():
+    """Todos os valores da tabela devem ser strings não vazias."""
+    for code, desc in _WMO_DESCRIPTIONS.items():
+        assert isinstance(desc, str), f"Código {code} não é string"
+        assert len(desc) > 0, f"Código {code} tem descrição vazia"
+
+# ── Testes de integração do execute() ────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_get_coordinates_empty_results(weather_skill):
@@ -150,14 +195,48 @@ async def test_execute_forecast_error(weather_skill):
             assert "Erro de formatação ou sem dados" in res["error"]
 
 @pytest.mark.asyncio
-async def test_execute_success(weather_skill):
+async def test_execute_success_condition_is_readable_string(weather_skill):
+    """Task 2.1 + 2.2: payload deve ter 'condition' (string legível) e NÃO 'condition_code'."""
+    forecast_data = {
+        "temperature_2m": 25.0,
+        "relative_humidity_2m": 60,
+        "precipitation_probability": 10,
+        "weather_code": 2,  # "Parcialmente nublado"
+    }
     with patch.object(weather_skill, "get_coordinates", return_value=(-23.5, -46.6, "São Paulo")):
-        with patch.object(weather_skill, "get_forecast", return_value={"temperature_2m": 25.0, "precipitation_probability": 0}):
+        with patch.object(weather_skill, "get_forecast", return_value=forecast_data):
             res = await weather_skill.execute({}, "São Paulo")
+
             assert res["status"] == "success"
-            assert res["data"]["location"] == "São Paulo"
-            assert res["data"]["temperature"] == 25.0
-            assert res["data"]["rain_probability"] == 0
+            data = res["data"]
+            assert data["location"] == "São Paulo"
+            assert data["temperature"] == 25.0
+            assert data["rain_probability"] == 10
+
+            # Bug fix: deve ser string legível, não número
+            assert "condition" in data
+            assert isinstance(data["condition"], str)
+            assert data["condition"] == "Parcialmente nublado"
+
+            # Bug fix: campo antigo NÃO deve estar presente
+            assert "condition_code" not in data
+
+@pytest.mark.asyncio
+async def test_execute_success_unknown_weather_code(weather_skill):
+    """Código WMO desconhecido deve resultar em fallback legível, não crash."""
+    forecast_data = {
+        "temperature_2m": 20.0,
+        "relative_humidity_2m": 55,
+        "precipitation_probability": 0,
+        "weather_code": 42,  # não existe na tabela WMO padrão
+    }
+    with patch.object(weather_skill, "get_coordinates", return_value=(-15.0, -47.0, "Brasília")):
+        with patch.object(weather_skill, "get_forecast", return_value=forecast_data):
+            res = await weather_skill.execute({}, "Brasília")
+
+            assert res["status"] == "success"
+            assert "desconhecida" in res["data"]["condition"]
+            assert "42" in res["data"]["condition"]
 
 @pytest.mark.asyncio
 async def test_execute_api_error(weather_skill):
@@ -165,3 +244,5 @@ async def test_execute_api_error(weather_skill):
         res = await weather_skill.execute({}, "São Paulo")
         assert res["status"] == "error"
         assert "Erro de comunicação com a API" in res["error"]
+
+


### PR DESCRIPTION
## 🐛 Fix #122 — Skill de Clima retornando código numérico incompreensível

### Problema

A skill de previsão do tempo retornava ao LLM um campo `condition_code` com um inteiro WMO bruto (ex: `2`). O LLM às vezes repassava esse número diretamente ao usuário, resultando em respostas como:

> "A temperatura é 22°C e o código de condição é 2."

### Solução

- **Tabela WMO → PT-BR**: adicionada `_WMO_DESCRIPTIONS` com 28 mapeamentos (códigos 0–99 conforme Open-Meteo)
- **Função `_wmo_description(code)`**: converte o inteiro para string legível com fallback seguro para códigos desconhecidos
- **Payload corrigido**: campo `condition_code` substituído por `condition` (string) antes de entregar ao LLM

### Antes / Depois

```python
# Antes (bugado)
"condition_code": current.get("weather_code")   # ex: 2

# Depois (corrigido)
"condition": _wmo_description(current.get("weather_code", -1))   # ex: "Parcialmente nublado"
```

### Testes

- 8 novos testes em `test_weather_manager.py`:
  - Código 0 → "Céu limpo", código 2 → "Parcialmente nublado"
  - Código de borda 99 → "Trovoada com granizo intenso"
  - Código desconhecido → fallback com número (não crash)
  - Tabela sem valores vazios
  - `condition_code` não presente no payload (regressão)
- Suite completa: **351 passed, 1 skipped** ✅

### Validação manual

- [ ] Testar no Telegram: "Como está o tempo em São Paulo?" → confirmar resposta com descrição textual