### PR TITLE
feat: Refatorar formato da lista de lembretes e ordenar por ID

### DIFF
--- a/openspec/changes/format-reminders-list/proposal.md
+++ b/openspec/changes/format-reminders-list/proposal.md
@@ -1,0 +1,15 @@
+# Format Reminders List
+
+## Context
+Atualmente, o comando ou skill `list_reminders` retorna os lembretes do usuário em uma lista não ordenada (geralmente pela data de disparo `remind_at`). O formato em texto, embora funcional, pode ser confuso estruturalmente em listas longas ou quando tarefas automáticas se misturam com lembretes comuns. O usuário solicitou uma melhoria para formatar melhor a lista e ordená-la estritamente por ID, o que facilita operações subsequentes (como cancelar ou editar um lembrete pelo seu ID).
+
+## Proposed Change
+A alteração envolve modificar a lógica e a query SQL do skill `ListRemindersSkill` (e `ReminderManager.get_active_reminders` se necessário) para garantir que os resultados retornados estejam ordenados por `id` crescente. Além disso, o output em texto markdown deve ser reformatado para ser mais amigável, possivelmente adicionando indentação ou emojis padronizados para distinguir tarefas normais de automáticas, tudo dentro da restrição de "diet" e simplicidade da interface do Telegram.
+
+## Impact
+- **UX**: A lista de lembretes será mais limpa e ordenada pelo ID.
+- **Performance**: Nenhuma penalidade significativa, apenas a alteração de um `ORDER BY` no SQL e pequenos ajustes na string formatting.
+- **Retrocompatibilidade**: Mínimo impacto, não afeta o agente ou as assinaturas de chamadas de skills.
+
+## Rationale
+Ordenar por `id` facilita a vida do usuário ao rodar comandos de deleção/atualização, já que a leitura é feita de cima para baixo de forma incremental. Melhorar a apresentação evita confusão com links, metadados de agendamento, etc., melhorando a experiência no Telegram.

--- a/openspec/changes/format-reminders-list/specs/reminders/spec.md
+++ b/openspec/changes/format-reminders-list/specs/reminders/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+### Requirement: Reminder Management
+The system MUST allow value listing and deletion of scheduled reminders, presenting the pending reminders ordered ascendingly by their ID.
+
+#### Scenario: List Reminders
+1.  User asks: "Quais são meus lembretes?".
+2.  System responds with a formatted, user-friendly list of PENDING reminders.
+3.  The list MUST be strictly ordered by the reminder `ID` in ascending order.
+4.  Each item in the list clearly separates its visual elements (ID, message, next trigger time, recurrence, and task indicators).
+
+#### Scenario: Delete Reminder
+1.  User asks: "Cancele o lembrete 1".
+2.  System confirms deletion.
+3.  The specific reminder does NOT fire at the scheduled time.

--- a/openspec/changes/format-reminders-list/tasks.md
+++ b/openspec/changes/format-reminders-list/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+1. - [x] **Atualizar Query SQL:** Modificar `ReminderManager.get_active_reminders` para ordenar os resultados por `id ASC` em vez de `remind_at ASC`.
+2. - [x] **Refatorar Formatação:** Atualizar `ListRemindersSkill.execute` para exibir os lembretes de forma mais legível no Telegram, garantindo que o ID seja o principal elemento de destaque e as informações adicionais (recorrência, tipo de tarefa) estejam bem espaçadas ou separadas visualmente.
+3. - [x] **Validação Manual:** Testar a exibição da lista com diferentes tipos de lembretes (pontuais, recorrentes e tarefas).

--- a/skills/reminders.py
+++ b/skills/reminders.py
@@ -35,7 +35,7 @@ class ReminderManager:
                 async with db.execute("""
                     SELECT id, message, remind_at, recurrence, is_task FROM reminders
                     WHERE user_id = ? AND status = 'PENDING'
-                    ORDER BY remind_at ASC
+                    ORDER BY id ASC
                 """, (user_id,)) as cursor:
                     rows = await cursor.fetchall()
                     return rows
@@ -686,7 +686,7 @@ class ListRemindersSkill(BaseSkill):
                 for r in formatted_reminders:
                     rec_str = f" 🔁 {self._recurrence_label(r['recurrence'])}" if r.get("recurrence") else ""
                     task_str = " | Tarefa automática" if r.get("is_task") else ""
-                    lines.append(f"* [ID {r['id']}] {r['message']} (próximo: {r['at']}{rec_str}{task_str})")
+                    lines.append(f"* `[ID {r['id']}]` **{r['message']}**\n  _(próximo: {r['at']}{rec_str}{task_str})_")
                 summary = "\n".join(lines)
 
             return self.success({


### PR DESCRIPTION
Implementação do OpenSpec format-reminders-list para ordenação e melhor visualização dos lembretes pendentes na interface Telegram.