### PR TITLE
fix: remove description truncation in capabilities display

### DIFF
--- a/skills/introspection.py
+++ b/skills/introspection.py
@@ -99,10 +99,8 @@ class IntrospectionSkill(BaseSkill):
 
         summary = []
         for group_data in groups.values():
-            # Condense all tool descriptions into one short summary per group
+            # Combine all tool descriptions into one summary per group
             combined = "; ".join(group_data["descriptions"])
-            if len(combined) > 120:
-                combined = combined[:117] + "..."
             summary.append({
                 "group": group_data["group"],
                 "emoji": group_data["emoji"],

--- a/tests/test_introspection_skill.py
+++ b/tests/test_introspection_skill.py
@@ -167,11 +167,12 @@ class TestIntrospectionSkill:
         assert data["tools"][0]["name"] == "get_weather"
 
     @pytest.mark.asyncio
-    async def test_list_all_skills_truncates_long_description(self):
-        """Descriptions combined beyond 120 chars should be truncated with '...'."""
+    async def test_list_all_skills_shows_full_description(self):
+        """Descriptions should be displayed in full without truncation."""
+        long_description = "A" * 130
         long_skill = _make_mock_skill(
             "verbose_tool",
-            "A" * 130,  # Forces the truncation branch (>120 chars)
+            long_description,
             skill_group="verbose",
             skill_group_emoji="🔤",
         )
@@ -183,5 +184,5 @@ class TestIntrospectionSkill:
         verbose_group = next(
             g for g in result["data"]["groups"] if g["group"] == "verbose"
         )
-        assert verbose_group["summary"].endswith("...")
-        assert len(verbose_group["summary"]) <= 120
+        assert verbose_group["summary"] == long_description
+        assert not verbose_group["summary"].endswith("...")


### PR DESCRIPTION
## Summary
Remove o limite de 120 caracteres que estava cortando as descrições das capacidades quando o bot lista suas funcionalidades.

## Changes
- Remove lógica de truncamento em `IntrospectionSkill._list_all_skills()`
- Atualiza teste para verificar que descrições completas são exibidas

## Before
```
📅 Calendar — Gerencia eventos no Google Calendar: listar, criar e cancelar eventos. Use 'setup_calendar' para configurar autentica...
```

## After
```
📅 Calendar — Gerencia eventos no Google Calendar: listar, criar e cancelar eventos. Use 'setup_calendar' para configurar autenticação OAuth2.
```

## Test plan
- [x] Testes passando: `pytest tests/test_introspection_skill.py -v`
- [ ] Verificar que as descrições completas aparecem quando usuário pergunta sobre capacidades do bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)