### PR TITLE
Prioritize config values over LLM kwargs in Job Hunter skill

### DIFF
--- a/skills/job_hunter.py
+++ b/skills/job_hunter.py
@@ -97,10 +97,26 @@ class JobHunterRunSearchSkill(BaseSkill):
         if err:
             return self.error(err)
 
-        sources: Optional[List[str]] = kwargs.get("sources") or config.JOB_HUNTER_SOURCES
-        keywords: Optional[List[str]] = kwargs.get("keywords") or config.JOB_HUNTER_KEYWORDS
+        _kw_sources = kwargs.get("sources")
+        _kw_keywords = kwargs.get("keywords")
+        _kw_cutoff = kwargs.get("score_cutoff")
+
+        sources: Optional[List[str]] = _kw_sources or config.JOB_HUNTER_SOURCES
+        keywords: Optional[List[str]] = _kw_keywords or config.JOB_HUNTER_KEYWORDS
         prompt_override: Optional[str] = kwargs.get("prompt_override")
-        score_cutoff: Optional[float] = kwargs.get("score_cutoff") or config.JOB_HUNTER_SCORE_CUTOFF
+        score_cutoff: Optional[float] = _kw_cutoff or config.JOB_HUNTER_SCORE_CUTOFF
+
+        sources_origin = "kwargs" if _kw_sources else "config"
+        keywords_origin = "kwargs" if _kw_keywords else "config"
+        cutoff_origin = "kwargs" if _kw_cutoff is not None else "config"
+
+        logger.info(
+            "Job Hunter: valores efetivos — "
+            "sources=%s [%s], keywords=%s [%s], score_cutoff=%s [%s]",
+            sources, sources_origin,
+            keywords, keywords_origin,
+            score_cutoff, cutoff_origin,
+        )
 
         if sources and not all(isinstance(s, str) for s in sources):
             return self.error("Fontes (sources) devem ser uma lista de strings.")
@@ -117,7 +133,7 @@ class JobHunterRunSearchSkill(BaseSkill):
         if score_cutoff is not None:
             body["score_cutoff"] = float(score_cutoff)
 
-        logger.info(f"Job Hunter: iniciando busca com overrides={list(body.keys())}")
+        logger.info("Job Hunter: iniciando busca com body_keys=%s", list(body.keys()))
 
         try:
             response = await asyncio.wait_for(

--- a/skills/job_hunter.py
+++ b/skills/job_hunter.py
@@ -101,14 +101,17 @@ class JobHunterRunSearchSkill(BaseSkill):
         _kw_keywords = kwargs.get("keywords")
         _kw_cutoff = kwargs.get("score_cutoff")
 
-        sources: Optional[List[str]] = _kw_sources or config.JOB_HUNTER_SOURCES
-        keywords: Optional[List[str]] = _kw_keywords or config.JOB_HUNTER_KEYWORDS
+        # config.toml takes priority over LLM-provided kwargs to prevent
+        # hallucinated values (e.g. from failed_generation recovery) from
+        # overriding the user's personal preferences.
+        sources: Optional[List[str]] = config.JOB_HUNTER_SOURCES or _kw_sources
+        keywords: Optional[List[str]] = config.JOB_HUNTER_KEYWORDS or _kw_keywords
         prompt_override: Optional[str] = kwargs.get("prompt_override")
-        score_cutoff: Optional[float] = _kw_cutoff or config.JOB_HUNTER_SCORE_CUTOFF
+        score_cutoff: Optional[float] = config.JOB_HUNTER_SCORE_CUTOFF or _kw_cutoff
 
-        sources_origin = "kwargs" if _kw_sources else "config"
-        keywords_origin = "kwargs" if _kw_keywords else "config"
-        cutoff_origin = "kwargs" if _kw_cutoff is not None else "config"
+        sources_origin = "config" if config.JOB_HUNTER_SOURCES else "kwargs"
+        keywords_origin = "config" if config.JOB_HUNTER_KEYWORDS else "kwargs"
+        cutoff_origin = "config" if config.JOB_HUNTER_SCORE_CUTOFF is not None else "kwargs"
 
         logger.info(
             "Job Hunter: valores efetivos — "

--- a/tests/test_job_hunter_skill.py
+++ b/tests/test_job_hunter_skill.py
@@ -162,7 +162,7 @@ class TestJobHunterRunSearchSkill(unittest.IsolatedAsyncioTestCase):
     @patch("skills.job_hunter.config.JOB_HUNTER_KEYWORDS", ["Agente de IA"])
     @patch("skills.job_hunter.config.JOB_HUNTER_SCORE_CUTOFF", 7.5)
     @patch("skills.job_hunter.requests.post")
-    async def test_llm_overrides_take_priority_over_env(self, mock_post):
+    async def test_config_takes_priority_over_llm_kwargs(self, mock_post):
         mock_response = MagicMock()
         mock_response.json.return_value = {"status": "success", "fetched": 2, "approved": 1}
         mock_response.raise_for_status = MagicMock()
@@ -177,10 +177,10 @@ class TestJobHunterRunSearchSkill(unittest.IsolatedAsyncioTestCase):
 
         _, call_kwargs = mock_post.call_args
         body = call_kwargs["json"]
-        # LLM args should win over env config
-        self.assertEqual(body["sources"], ["gupy.io"])
-        self.assertEqual(body["keywords"], ["Producer"])
-        self.assertEqual(body["score_cutoff"], 9.0)
+        # config.toml must win over LLM kwargs to prevent hallucinated values
+        self.assertEqual(body["sources"], ["lever.co"])
+        self.assertEqual(body["keywords"], ["Agente de IA"])
+        self.assertEqual(body["score_cutoff"], 7.5)
 
     # --- Error handling ---
 


### PR DESCRIPTION
## Summary
Updated the Job Hunter skill to prioritize configuration file values over LLM-provided kwargs, preventing hallucinated values from overriding user preferences. Added detailed logging to track which values are being used and their origin.

## Key Changes
- **Reversed priority order**: Configuration values now take precedence over kwargs for `sources`, `keywords`, and `score_cutoff` parameters
- **Added origin tracking**: Introduced `sources_origin`, `keywords_origin`, and `cutoff_origin` variables to track whether each parameter comes from config or kwargs
- **Enhanced logging**: Added comprehensive info-level logging that displays effective parameter values and their origin (config vs kwargs)
- **Improved log formatting**: Converted f-string log statement to use proper parameterized logging for consistency

## Implementation Details
- The change prevents failed generation recovery or other LLM hallucinations from overriding user-defined preferences stored in `config.toml`
- Origin tracking uses a simple ternary check: if the config value is set (non-empty/non-None), it's marked as "config", otherwise "kwargs"
- Logging now clearly shows which parameters are being used and where they came from, improving debuggability

https://claude.ai/code/session_016L6AJuTRBK1pfLoTf87mXY