### PR TITLE
fix(calendar): support timezone naive datetimes in reminder creation

### DIFF
--- a/skills/calendar_reminder_bridge.py
+++ b/skills/calendar_reminder_bridge.py
@@ -311,6 +311,10 @@ class CalendarReminderBridge:
             else:
                 start_dt = datetime.fromisoformat(start_str)
 
+            # Ensure it is timezone-aware. If naive (e.g. all-day event YYYY-MM-DD), assume UTC.
+            if start_dt.tzinfo is None or start_dt.tzinfo.utcoffset(start_dt) is None:
+                start_dt = start_dt.replace(tzinfo=timezone.utc)
+
             # Calculate reminder time (10 minutes before event)
             remind_at = start_dt - timedelta(minutes=10)
 

--- a/tests/test_calendar_reminder_bridge.py
+++ b/tests/test_calendar_reminder_bridge.py
@@ -209,6 +209,30 @@ class TestEventReminderCreation:
             mock_add.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_create_event_reminder_all_day_event(self, bridge):
+        """Verifica que parsing de evento de dia inteiro (sem fuso horário) funciona e não lança TypeError."""
+        tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%d")
+        event = {
+            "id": "all_day_123",
+            "iCalUID": "all-day-ical-uid",
+            "summary": "Evento Dia Inteiro",
+            "start": tomorrow,
+        }
+
+        with patch.object(bridge.reminder_manager, 'add_reminder', return_value=3) as mock_add:
+            with patch('aiosqlite.connect') as mock_connect:
+                mock_db = AsyncMock()
+                mock_db.execute = AsyncMock()
+                mock_db.commit = AsyncMock()
+                mock_connect.return_value.__aenter__.return_value = mock_db
+
+                # Não deve lançar TypeError (e deve disparar o reminder)
+                await bridge._create_event_reminder(event)
+
+                # Verifica que add_reminder foi chamado
+                assert mock_add.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_fetch_upcoming_events_uses_utc(self, bridge):
         """Verifica que _fetch_upcoming_events usa datetime.now(timezone.utc)."""
         with patch.object(bridge, '_get_valid_credentials', return_value=MagicMock(token="test_token")):


### PR DESCRIPTION
This PR fixes a bug in the Google Calendar sync bridge when handling all-day events.

### Cause
All-day events (e.g., `"start": "2026-06-23"`) do not contain timezone info or time parts, which makes `datetime.fromisoformat` return a **timezone-naive** datetime. Comparing this with `datetime.now(timezone.utc)` (which is **timezone-aware**) throws a `TypeError: can't compare offset-naive and offset-aware datetimes`.

### Solution
- Checked if the parsed `datetime` has a timezone (`tzinfo` is None). If it is naive, we dynamically apply the UTC timezone using `.replace(tzinfo=timezone.utc)`.
- Added `test_create_event_reminder_all_day_event` in `tests/test_calendar_reminder_bridge.py` to cover this case and ensure no regression.
- Tested and ran the Pyright check without errors.