### PR TITLE
fix(calendar): add Portuguese weekday name to system prompt and event list

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -722,7 +722,13 @@ class AgentBrain:
         tools_context = "\n".join(available_tools_desc) if available_tools_desc else "Nenhuma ferramenta disponível no momento."
 
         user_name = context.get('user_name', 'Usuário')
-        current_time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        now = datetime.now()
+        weekday_map = {
+            0: "segunda-feira", 1: "terça-feira", 2: "quarta-feira", 
+            3: "quinta-feira", 4: "sexta-feira", 5: "sábado", 6: "domingo"
+        }
+        weekday_pt = weekday_map.get(now.weekday(), "")
+        current_time_str = f"{weekday_pt}, {now.strftime('%Y-%m-%d %H:%M:%S')}"
 
         # Build bot full name — "Curupira" + optional surname set during onboarding
         assistant_surname = context.get('assistant_surname', '').strip()

--- a/skills/google_calendar.py
+++ b/skills/google_calendar.py
@@ -903,11 +903,27 @@ class GoogleCalendarSkill(BaseSkill):
                     except Exception as parse_err:
                         self.logger.warning(f"Erro ao parsear datas de evento de dia inteiro: {parse_err}")
 
+                # Determinar o dia da semana em português
+                weekday_pt = ""
+                if start_val:
+                    try:
+                        date_str = start_val[:10]
+                        from datetime import date
+                        event_date = date.fromisoformat(date_str)
+                        weekday_map = {
+                            0: "segunda-feira", 1: "terça-feira", 2: "quarta-feira", 
+                            3: "quinta-feira", 4: "sexta-feira", 5: "sábado", 6: "domingo"
+                        }
+                        weekday_pt = weekday_map.get(event_date.weekday(), "")
+                    except Exception as weekday_err:
+                        self.logger.warning(f"Erro ao calcular dia da semana para o evento: {weekday_err}")
+
                 event = {
                     "id": event_id,
                     "summary": summary,
                     "start": start_val,
                     "end": end_datetime or end_date,
+                    "weekday": weekday_pt,
                     "description": item.get("description", ""),
                 }
                 events.append(event)

--- a/tests/test_google_calendar.py
+++ b/tests/test_google_calendar.py
@@ -653,6 +653,56 @@ class TestListCalendarEvents:
         events = result["data"]["events"]
         assert len(events) == 1
         assert events[0]["id"] == "event_today"
+        assert events[0]["weekday"] == "quarta-feira"
+
+    @pytest.mark.asyncio
+    async def test_list_calendar_events_includes_weekday_field(self, skill):
+        """Verifica se o campo weekday é adicionado corretamente para cada dia da semana."""
+        mock_api_response = {
+            "items": [
+                {
+                    "id": "event_mon",
+                    "summary": "Evento Segunda",
+                    "start": {"date": "2026-03-09"},
+                    "end": {"date": "2026-03-10"},
+                },
+                {
+                    "id": "event_wed",
+                    "summary": "Evento Quarta",
+                    "start": {"dateTime": "2026-03-11T10:00:00-03:00"},
+                    "end": {"dateTime": "2026-03-11T11:00:00-03:00"},
+                },
+            ]
+        }
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_api_response
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        mock_now = datetime(2026, 3, 9, 8, 0, 0) # 2026-03-09 é Segunda
+
+        with patch.object(skill, '_get_client', return_value=mock_client), \
+             patch('skills.google_calendar.datetime') as mock_datetime:
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.fromisoformat = datetime.fromisoformat
+            result = await skill._list_calendar_events(time_range="week")
+
+        assert result["status"] == "success"
+        events = result["data"]["events"]
+        assert len(events) == 2
+
+        # event_mon should be "segunda-feira"
+        event_mon = next(e for e in events if e["id"] == "event_mon")
+        assert event_mon["weekday"] == "segunda-feira"
+
+        # event_wed should be "quarta-feira"
+        event_wed = next(e for e in events if e["id"] == "event_wed")
+        assert event_wed["weekday"] == "quarta-feira"
 
     @pytest.mark.asyncio
     async def test_list_calendar_events_not_authenticated(self, skill):


### PR DESCRIPTION
Esse PR adiciona o dia da semana em português ao system prompt do agente e no retorno dos eventos da tool do Google Calendar para evitar que o modelo erre cálculos de calendário.