### PR TITLE
fix(job_hunter): correct config fallback logic and enrich get_defaults

### DIFF
--- a/skills/job_hunter.py
+++ b/skills/job_hunter.py
@@ -104,13 +104,13 @@ class JobHunterRunSearchSkill(BaseSkill):
         # config.toml takes priority over LLM-provided kwargs to prevent
         # hallucinated values (e.g. from failed_generation recovery) from
         # overriding the user's personal preferences.
-        sources: Optional[List[str]] = config.JOB_HUNTER_SOURCES or _kw_sources
-        keywords: Optional[List[str]] = config.JOB_HUNTER_KEYWORDS or _kw_keywords
+        sources: Optional[List[str]] = config.JOB_HUNTER_SOURCES if config.JOB_HUNTER_SOURCES is not None else _kw_sources
+        keywords: Optional[List[str]] = config.JOB_HUNTER_KEYWORDS if config.JOB_HUNTER_KEYWORDS is not None else _kw_keywords
         prompt_override: Optional[str] = kwargs.get("prompt_override")
-        score_cutoff: Optional[float] = config.JOB_HUNTER_SCORE_CUTOFF or _kw_cutoff
+        score_cutoff: Optional[float] = config.JOB_HUNTER_SCORE_CUTOFF if config.JOB_HUNTER_SCORE_CUTOFF is not None else _kw_cutoff
 
-        sources_origin = "config" if config.JOB_HUNTER_SOURCES else "kwargs"
-        keywords_origin = "config" if config.JOB_HUNTER_KEYWORDS else "kwargs"
+        sources_origin = "config" if config.JOB_HUNTER_SOURCES is not None else "kwargs"
+        keywords_origin = "config" if config.JOB_HUNTER_KEYWORDS is not None else "kwargs"
         cutoff_origin = "config" if config.JOB_HUNTER_SCORE_CUTOFF is not None else "kwargs"
 
         logger.info(
@@ -213,7 +213,26 @@ class JobHunterGetDefaultsSkill(BaseSkill):
                 timeout=20,
             )
             response.raise_for_status()
-            return self.success(response.json())
+            server_defaults = response.json()
+
+            effective_sources = config.JOB_HUNTER_SOURCES if config.JOB_HUNTER_SOURCES is not None else server_defaults.get("sources")
+            effective_keywords = config.JOB_HUNTER_KEYWORDS if config.JOB_HUNTER_KEYWORDS is not None else server_defaults.get("keywords")
+            effective_score_cutoff = config.JOB_HUNTER_SCORE_CUTOFF if config.JOB_HUNTER_SCORE_CUTOFF is not None else server_defaults.get("score_cutoff")
+
+            return self.success({
+                "server_defaults": server_defaults,
+                "local_overrides": {
+                    "sources": config.JOB_HUNTER_SOURCES,
+                    "keywords": config.JOB_HUNTER_KEYWORDS,
+                    "score_cutoff": config.JOB_HUNTER_SCORE_CUTOFF,
+                },
+                "effective_criteria": {
+                    "sources": effective_sources,
+                    "keywords": effective_keywords,
+                    "score_cutoff": effective_score_cutoff,
+                    "prompt_evaluation": server_defaults.get("prompt_override"),
+                }
+            })
         except asyncio.TimeoutError:
             return self.error("Timeout ao buscar configurações do servidor (>20s).")
         except requests.HTTPError as e:

--- a/tests/test_job_hunter_skill.py
+++ b/tests/test_job_hunter_skill.py
@@ -182,6 +182,26 @@ class TestJobHunterRunSearchSkill(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["keywords"], ["Agente de IA"])
         self.assertEqual(body["score_cutoff"], 7.5)
 
+    @patch("skills.job_hunter.config.JOB_HUNTER_URL", FAKE_URL)
+    @patch("skills.job_hunter.config.JOB_HUNTER_TOKEN", FAKE_TOKEN)
+    @patch("skills.job_hunter.config.JOB_HUNTER_SOURCES", [])
+    @patch("skills.job_hunter.config.JOB_HUNTER_KEYWORDS", ["Agente de IA"])
+    @patch("skills.job_hunter.config.JOB_HUNTER_SCORE_CUTOFF", 7.5)
+    @patch("skills.job_hunter.requests.post")
+    async def test_run_search_empty_sources_not_overridden_by_kwargs(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "success", "fetched": 1, "approved": 0}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        # A IA tenta sugerir gupy.io, mas config.toml tem [] que deve prevalecer
+        await self.skill.execute({}, sources=["gupy.io"])
+
+        _, call_kwargs = mock_post.call_args
+        body = call_kwargs["json"]
+        self.assertNotIn("sources", body) # Como sources é [], ele não vai no JSON (if sources:)
+        self.assertEqual(body["keywords"], ["Agente de IA"])
+
     # --- Error handling ---
 
     @patch("skills.job_hunter.config.JOB_HUNTER_URL", FAKE_URL)
@@ -257,6 +277,9 @@ class TestJobHunterGetDefaultsSkill(unittest.IsolatedAsyncioTestCase):
 
     @patch("skills.job_hunter.config.JOB_HUNTER_URL", FAKE_URL)
     @patch("skills.job_hunter.config.JOB_HUNTER_TOKEN", FAKE_TOKEN)
+    @patch("skills.job_hunter.config.JOB_HUNTER_SOURCES", None)
+    @patch("skills.job_hunter.config.JOB_HUNTER_KEYWORDS", None)
+    @patch("skills.job_hunter.config.JOB_HUNTER_SCORE_CUTOFF", None)
     @patch("skills.job_hunter.requests.get")
     async def test_get_defaults_success(self, mock_get):
         expected = {
@@ -271,11 +294,41 @@ class TestJobHunterGetDefaultsSkill(unittest.IsolatedAsyncioTestCase):
 
         result = await self.skill.execute({})
 
-        self.assertEqual(result["data"]["sources"], ["gupy.io"])
-        self.assertEqual(result["data"]["score_cutoff"], 7.0)
+        data = result["data"]
+        self.assertEqual(data["server_defaults"]["sources"], ["gupy.io"])
+        self.assertEqual(data["effective_criteria"]["sources"], ["gupy.io"])
+        self.assertEqual(data["effective_criteria"]["score_cutoff"], 7.0)
         mock_get.assert_called_once()
         call_args = mock_get.call_args
         self.assertIn("/api/config_endpoint", call_args[0][0])
+
+    @patch("skills.job_hunter.config.JOB_HUNTER_URL", FAKE_URL)
+    @patch("skills.job_hunter.config.JOB_HUNTER_TOKEN", FAKE_TOKEN)
+    @patch("skills.job_hunter.config.JOB_HUNTER_SOURCES", ["lever.co"])
+    @patch("skills.job_hunter.config.JOB_HUNTER_KEYWORDS", ["Agente de IA"])
+    @patch("skills.job_hunter.config.JOB_HUNTER_SCORE_CUTOFF", 8.0)
+    @patch("skills.job_hunter.requests.get")
+    async def test_get_defaults_with_local_overrides(self, mock_get):
+        expected = {
+            "sources": ["gupy.io"],
+            "keywords": ["Product Manager"],
+            "score_cutoff": 7.0,
+            "prompt_override": "Prompt default do servidor",
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = await self.skill.execute({})
+
+        data = result["data"]
+        self.assertEqual(data["server_defaults"]["sources"], ["gupy.io"])
+        self.assertEqual(data["local_overrides"]["sources"], ["lever.co"])
+        self.assertEqual(data["effective_criteria"]["sources"], ["lever.co"])
+        self.assertEqual(data["effective_criteria"]["keywords"], ["Agente de IA"])
+        self.assertEqual(data["effective_criteria"]["score_cutoff"], 8.0)
+        self.assertEqual(data["effective_criteria"]["prompt_evaluation"], "Prompt default do servidor")
 
     @patch("skills.job_hunter.config.JOB_HUNTER_URL", FAKE_URL)
     @patch("skills.job_hunter.config.JOB_HUNTER_TOKEN", FAKE_TOKEN)


### PR DESCRIPTION
Corrigido o bug na resolução de parâmetros onde listas vazias eram ignoradas e enriquecido o retorno da skill de defaults do Job Hunter com mesclagem local e remota.