### PR TITLE
fix(job_hunter): allow null values in parameters schema to prevent Groq validation HTTP 400 errors

### DIFF
--- a/skills/job_hunter.py
+++ b/skills/job_hunter.py
@@ -57,7 +57,7 @@ class JobHunterRunSearchSkill(BaseSkill):
             "type": "object",
             "properties": {
                 "sources": {
-                    "type": "array",
+                    "type": ["array", "null"],
                     "items": {"type": "string"},
                     "description": (
                         "Lista de domínios para buscar vagas "
@@ -66,7 +66,7 @@ class JobHunterRunSearchSkill(BaseSkill):
                     ),
                 },
                 "keywords": {
-                    "type": "array",
+                    "type": ["array", "null"],
                     "items": {"type": "string"},
                     "description": (
                         "Lista de palavras-chave para a busca "
@@ -75,14 +75,14 @@ class JobHunterRunSearchSkill(BaseSkill):
                     ),
                 },
                 "prompt_override": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "description": (
                         "Prompt customizado para avaliação das vagas pela IA. "
                         "Se omitido, usa o prompt padrão do servidor."
                     ),
                 },
                 "score_cutoff": {
-                    "type": "number",
+                    "type": ["number", "null"],
                     "description": (
                         "Nota mínima (0-10) para uma vaga ser aprovada. "
                         "Se omitido, usa a configuração pessoal ou o default do servidor."


### PR DESCRIPTION
This PR expands the JSON Schema types for optional parameters (`sources`, `keywords`, `prompt_override`, `score_cutoff`) in `JobHunterRunSearchSkill` parameters to accept `null`. This prevents strict tool call validation failures (HTTP 400 Bad Request errors) from the Groq API when the LLM decides to generate `null` for these fields.

Resolves the issue where the scheduled morning reminder `busca vagas agora` failed with "Desculpe, tive um problema de conexão com meu cérebro digital." (caused by Groq HTTP 400 validation error in tool calls).