### PR TITLE
fix(bot): prevent silent reschedule failures on Telegram ConnectTimeout and wait for network online in systemd

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -405,7 +405,11 @@ async def execute_reminder(context: ContextTypes.DEFAULT_TYPE):
             except Exception as send_err:
                 logging.error(f"Failed to notify user of task error for reminder {reminder_id}: {send_err}")
     else:
-        await context.bot.send_message(chat_id=chat_id, text=f"⏰ Lembrete: {message}")
+        try:
+            await context.bot.send_message(chat_id=chat_id, text=f"⏰ Lembrete: {message}")
+        except Exception as e:
+            task_error = True
+            logging.error(f"Error sending simple reminder {reminder_id}: {e}")
 
     # --- Reschedule or mark as sent ---
     if recurrence:

--- a/curupira_wrapper.sh
+++ b/curupira_wrapper.sh
@@ -47,7 +47,8 @@ function install_daemon {
     cat <<EOF > "$SERVICE_FILE"
 [Unit]
 Description=Curupira BOT Service
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple

--- a/tests/test_execute_reminder.py
+++ b/tests/test_execute_reminder.py
@@ -341,6 +341,42 @@ class TestExecuteReminderCallback(unittest.IsolatedAsyncioTestCase):
         # Should not mark as sent
         mgr.mark_as_sent.assert_not_awaited()
 
+    async def test_is_task_false_send_message_error_does_not_mark_sent(self):
+        """When send_message raises an exception for is_task=False, does not mark the reminder as sent."""
+        context = _make_context(reminder_data={"id": 82, "msg": "tomar café"})
+        mgr = _make_reminder_manager(message="tomar café", is_task=False, recurrence=None)
+        mem_mgr = _make_memory_manager()
+        brain = MagicMock()
+        context.bot.send_message.side_effect = RuntimeError("Telegram connection failed")
+
+        await _execute_reminder_impl(context, mgr, mem_mgr, brain)
+
+        context.bot.send_message.assert_awaited_once()
+        # Should not mark as sent because of the exception
+        mgr.mark_as_sent.assert_not_awaited()
+
+    async def test_is_task_false_send_message_error_reschedules_recurring(self):
+        """When send_message raises an exception for is_task=False and recurrence is set, still reschedules the reminder."""
+        context = _make_context(reminder_data={"id": 83, "msg": "tomar café"})
+        from datetime import datetime, timedelta
+        remind_at = datetime.now() + timedelta(hours=1)
+        mgr = _make_reminder_manager(message="tomar café", is_task=False, recurrence="daily", remind_at=remind_at)
+        mgr.reset_recurring_reminder = AsyncMock()
+        mgr._next_occurrence = MagicMock(return_value=datetime.now() + timedelta(days=1))
+        
+        mem_mgr = _make_memory_manager()
+        brain = MagicMock()
+        context.bot.send_message.side_effect = RuntimeError("Telegram connection failed")
+
+        await _execute_reminder_impl(context, mgr, mem_mgr, brain)
+
+        context.bot.send_message.assert_awaited_once()
+        # Should still reschedule even if the message failed to send
+        mgr.reset_recurring_reminder.assert_awaited_once()
+        context.job_queue.run_once.assert_called_once()
+        # Should not mark as sent
+        mgr.mark_as_sent.assert_not_awaited()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR:
1. Wraps simple reminder dispatching (`context.bot.send_message`) inside a `try-except` block to capture network issues (like `ConnectTimeout`). This ensures that if a network failure occurs, the rescheduling logic is still executed, preventing recurring reminders from dropping out silently, and allowing single reminders to try again on the next bot reboot.
2. Updates `curupira_wrapper.sh` to use `After=network-online.target` and `Wants=network-online.target` in the systemd service template, ensuring the bot starts only after a fully functioning internet connection is established (highly recommended for Raspberry Pi boot order).